### PR TITLE
Update testimonial link so it stays valid

### DIFF
--- a/index.html
+++ b/index.html
@@ -229,7 +229,7 @@ description: FreshRSS is lightweight, easy to work with, powerful, and customiza
             </blockquote>
 
             <figcaption>
-                <a href="https://twitter.com/scatmandan/status/1443201049276387330">@scatmandan</a>
+                <a href="https://danq.me/2021/09/29/freshrss-addiction/">@scatmandan</a>
             </figcaption>
         </figure>
 


### PR DESCRIPTION
Hi! I'm @scatmandan on Twitter. Along with most of the world, I'm imminently about to delete my Twitter account, which will break the testimonial link on your homepage (I've deleted most of my tweets already, but I've left that one up for now).

The tweet in which I gave you that testimonial was backed up to my blog, though: it can be found intact at https://danq.me/2021/09/29/freshrss-addiction/. So if you want that link to stay valid, you might like to update it to that URL instead! This PR proposes the necessary change.

(If you don't want to make that change, or you'd rather seek a different testimonial, that's fine too. Either way, I'll remain a huge FreshRSS fan. Congratulations on 10 years!)