### PR TITLE
Updated the cloud providers.

### DIFF
--- a/pages/cloud-providers.html
+++ b/pages/cloud-providers.html
@@ -28,7 +28,7 @@ description: You could be using FreshRSS in a few minutes.
 
         <div class="card flow-small">
             <div class="card__title">
-                Chère de Prince
+                La Bécasse
             </div>
 
             <p class="text-secondary">
@@ -36,24 +36,9 @@ description: You could be using FreshRSS in a few minutes.
             </p>
 
             <p>
-                <strong><a href="https://cheredeprince.net/">cheredeprince.net</a></strong>
+                <strong><a href="https://rss.cheredeprince.net/">cheredeprince.net</a></strong>
             </p>
         </div>
-
-        <div class="card flow-small">
-            <div class="card__title">
-                FACiL
-            </div>
-
-            <p class="text-secondary">
-                Quebec, pay what you want
-            </p>
-
-            <p>
-                <strong><a href="https://facil.services/">facil.services</a></strong>
-            </p>
-        </div>
-    </div>
 
     <div class="cols cols--wrap">
         <div class="card flow-small">
@@ -80,7 +65,7 @@ description: You could be using FreshRSS in a few minutes.
             </p>
 
             <p>
-                <strong><a href="https://hostux.network/">hostux.network</a></strong>
+                <strong><a href="https://rss.hostux.net/">hostux.network</a></strong>
             </p>
         </div>
 
@@ -94,7 +79,7 @@ description: You could be using FreshRSS in a few minutes.
             </p>
 
             <p>
-                <strong><a href="https://www.prodottoinrete.com/blogs/new_service_freshrss/">prodottoinrete.com</a></strong>
+                <strong><a href="https://freshrss.prodottoinrete.com/">prodottoinrete.com</a></strong>
             </p>
         </div>
     </div>
@@ -110,38 +95,9 @@ description: You could be using FreshRSS in a few minutes.
             </p>
 
             <p>
-                <strong><a href="https://services.siick.fr/">services.siick.fr</a></strong>
+                <strong><a href="https://rss.siick.fr/">services.siick.fr</a></strong>
             </p>
         </div>
-
-        <div class="card flow-small">
-            <div class="card__title">
-                ~vern
-            </div>
-
-            <p class="text-secondary">
-                English, free (donations accepted)
-            </p>
-
-            <p>
-                <strong><a href="https://rss.vern.cc/">rss.vern.cc</a></strong>
-            </p>
-        </div>
-
-        <div class="card flow-small">
-            <div class="card__title">
-                Zaclys
-            </div>
-
-            <p class="text-secondary">
-                French, 10 € / year
-            </p>
-
-            <p>
-                <strong><a href="https://www.zaclys.com">zaclys.com</a></strong>
-            </p>
-        </div>
-    </div>
 
     <p class="text-featured">
         Want to add your server to the list?<br />

--- a/pages/cloud-providers.html
+++ b/pages/cloud-providers.html
@@ -14,7 +14,7 @@ description: You could be using FreshRSS in a few minutes.
     <div class="cols cols--wrap">
         <div class="card flow-small">
             <div class="card__title">
-                <strong><a href="https://feeds.flossboxin.org.in/">FLOSS Feeds</a></strong>
+                FLOSS Feeds
             </div>
 
             <p class="text-secondary">
@@ -28,7 +28,7 @@ description: You could be using FreshRSS in a few minutes.
 
         <div class="card flow-small">
             <div class="card__title">
-                <strong><a href="https://cheredeprince.net/">Chère de Prince</a></strong>
+                Chère de Prince
             </div>
 
             <p class="text-secondary">
@@ -36,13 +36,14 @@ description: You could be using FreshRSS in a few minutes.
             </p>
 
             <p>
-                <strong><a href="https://rss.cheredeprince.net/">cheredeprince.net</a></strong>
+                <strong><a href="https://cheredeprince.net/">cheredeprince.net</a></strong>
+                <small> ⋅ <a href="https://rss.cheredeprince.net/">FreshRSS</a></small>
             </p>
         </div>
 
         <div class="card flow-small">
             <div class="card__title">
-                <strong><a href="https://journal.facil.services/">FACiL</a></strong>
+                FACiL
             </div>
 
             <p class="text-secondary">
@@ -51,14 +52,15 @@ description: You could be using FreshRSS in a few minutes.
 
             <p>
                 <strong><a href="https://facil.services/">facil.services</a></strong>
+                <small> ⋅ <a href="https://journal.facil.services/">FreshRSS</a></small>
             </p>
         </div>
     </div>
-        
-        <div class="cols cols--wrap">
+
+    <div class="cols cols--wrap">
         <div class="card flow-small">
             <div class="card__title">
-                <strong><a href="https://flus.fr">Flus</a></strong>
+                Flus
             </div>
 
             <p class="text-secondary">
@@ -72,7 +74,7 @@ description: You could be using FreshRSS in a few minutes.
 
         <div class="card flow-small">
             <div class="card__title">
-                <strong><a href="https://hostux.network/">Hostux</a></strong>
+                Hostux
             </div>
 
             <p class="text-secondary">
@@ -80,13 +82,14 @@ description: You could be using FreshRSS in a few minutes.
             </p>
 
             <p>
-                <strong><a href="https://rss.hostux.net/">hostux.network</a></strong>
+                <strong><a href="https://hostux.network/">hostux.network</a></strong>
+                <small> ⋅ <a href="https://rss.hostux.net/">FreshRSS</a></small>
             </p>
         </div>
 
         <div class="card flow-small">
             <div class="card__title">
-                <strong><a href="https://www.prodottoinrete.com/blogs/new_service_freshrss/">Prodottoinrete Group SRL</a></strong>
+                Prodottoinrete Group SRL
             </div>
 
             <p class="text-secondary">
@@ -94,7 +97,8 @@ description: You could be using FreshRSS in a few minutes.
             </p>
 
             <p>
-                <strong><a href="https://freshrss.prodottoinrete.com/">prodottoinrete.com</a></strong>
+                <strong><a href="https://prodottoinrete.com/">prodottoinrete.com</a></strong>
+                <small> ⋅ <a href="https://freshrss.prodottoinrete.com/">FreshRSS</a></small>
             </p>
         </div>
     </div>
@@ -102,7 +106,7 @@ description: You could be using FreshRSS in a few minutes.
     <div class="cols cols--wrap">
         <div class="card flow-small">
             <div class="card__title">
-                <strong><a href="https://siick.fr/">Siick's Services</a></strong>
+                Siick's Services
             </div>
 
             <p class="text-secondary">
@@ -110,23 +114,26 @@ description: You could be using FreshRSS in a few minutes.
             </p>
 
             <p>
-                <strong><a href="https://rss.siick.fr/">services.siick.fr</a></strong>
+                <strong><a href="https://services.siick.fr/">services.siick.fr</a></strong>
+                <small> ⋅ <a href="https://rss.siick.fr/">FreshRSS</a></small>
             </p>
         </div>
 
-            <div class="card flow-small">
+        <div class="card flow-small">
             <div class="card__title">
-                <strong><a href="https://www.zaclys.com">Zaclys</a></strong>
+                Zaclys
             </div>
 
             <p class="text-secondary">
-                French, 10 € / year
+                French, 10&nbsp;€&nbsp;/&nbsp;year
             </p>
 
             <p>
-                <strong><a href="https://www.zaclys.com/flux/">zaclys.com</a></strong>
+                <strong><a href="https://www.zaclys.com/">zaclys.com</a></strong>
+                <small> ⋅ <a href="https://www.zaclys.com/flux/">FreshRSS</a></small>
             </p>
         </div>
+    </div>
 
     <p class="text-featured">
         Want to add your server to the list?<br />

--- a/pages/cloud-providers.html
+++ b/pages/cloud-providers.html
@@ -11,7 +11,7 @@ description: You could be using FreshRSS in a few minutes.
         </p>
     </div>
 
-    <div class="cols cols--wrap">
+    <div class="grid">
         <div class="card flow-small">
             <div class="card__title">
                 FLOSS Feeds
@@ -55,9 +55,7 @@ description: You could be using FreshRSS in a few minutes.
                 <small> ⋅ <a href="https://journal.facil.services/">FreshRSS</a></small>
             </p>
         </div>
-    </div>
 
-    <div class="cols cols--wrap">
         <div class="card flow-small">
             <div class="card__title">
                 Flus
@@ -101,9 +99,7 @@ description: You could be using FreshRSS in a few minutes.
                 <small> ⋅ <a href="https://freshrss.prodottoinrete.com/">FreshRSS</a></small>
             </p>
         </div>
-    </div>
 
-    <div class="cols cols--wrap">
         <div class="card flow-small">
             <div class="card__title">
                 Siick's Services

--- a/pages/cloud-providers.html
+++ b/pages/cloud-providers.html
@@ -14,7 +14,7 @@ description: You could be using FreshRSS in a few minutes.
     <div class="cols cols--wrap">
         <div class="card flow-small">
             <div class="card__title">
-                FLOSS Feeds
+                <strong><a href="https://feeds.flossboxin.org.in/">FLOSS Feeds</a></strong>
             </div>
 
             <p class="text-secondary">
@@ -28,7 +28,7 @@ description: You could be using FreshRSS in a few minutes.
 
         <div class="card flow-small">
             <div class="card__title">
-                La Bécasse
+                <strong><a href="https://cheredeprince.net/">Chère de Prince</a></strong>
             </div>
 
             <p class="text-secondary">
@@ -40,10 +40,25 @@ description: You could be using FreshRSS in a few minutes.
             </p>
         </div>
 
-    <div class="cols cols--wrap">
         <div class="card flow-small">
             <div class="card__title">
-                Flus
+                <strong><a href="https://journal.facil.services/">FACiL</a></strong>
+            </div>
+
+            <p class="text-secondary">
+                Quebec, pay what you want
+            </p>
+
+            <p>
+                <strong><a href="https://facil.services/">facil.services</a></strong>
+            </p>
+        </div>
+    </div>
+        
+        <div class="cols cols--wrap">
+        <div class="card flow-small">
+            <div class="card__title">
+                <strong><a href="https://flus.fr">Flus</a></strong>
             </div>
 
             <p class="text-secondary">
@@ -57,7 +72,7 @@ description: You could be using FreshRSS in a few minutes.
 
         <div class="card flow-small">
             <div class="card__title">
-                Hostux
+                <strong><a href="https://hostux.network/">Hostux</a></strong>
             </div>
 
             <p class="text-secondary">
@@ -71,7 +86,7 @@ description: You could be using FreshRSS in a few minutes.
 
         <div class="card flow-small">
             <div class="card__title">
-                Prodottoinrete Group SRL
+                <strong><a href="https://www.prodottoinrete.com/blogs/new_service_freshrss/">Prodottoinrete Group SRL</a></strong>
             </div>
 
             <p class="text-secondary">
@@ -87,7 +102,7 @@ description: You could be using FreshRSS in a few minutes.
     <div class="cols cols--wrap">
         <div class="card flow-small">
             <div class="card__title">
-                Siick’s services
+                <strong><a href="https://siick.fr/">Siick's Services</a></strong>
             </div>
 
             <p class="text-secondary">
@@ -96,6 +111,20 @@ description: You could be using FreshRSS in a few minutes.
 
             <p>
                 <strong><a href="https://rss.siick.fr/">services.siick.fr</a></strong>
+            </p>
+        </div>
+
+            <div class="card flow-small">
+            <div class="card__title">
+                <strong><a href="https://www.zaclys.com">Zaclys</a></strong>
+            </div>
+
+            <p class="text-secondary">
+                French, 10 € / year
+            </p>
+
+            <p>
+                <strong><a href="https://www.zaclys.com/flux/">zaclys.com</a></strong>
             </p>
         </div>
 

--- a/static/style.css
+++ b/static/style.css
@@ -325,6 +325,13 @@ blockquote {
     }
 }
 
+.grid {
+    display: grid;
+
+    grid-gap: 1rem;
+    grid-template-columns: repeat(auto-fill, minmax(15rem, 1fr));
+}
+
 .edge-gap {
     padding-right: 0.5rem;
     padding-left: 0.5rem;


### PR DESCRIPTION
Removed:
1. vern instance as is dead for sometime now, and the whole vern domain itself is dead.
2. Facil services, as they no longer provide for FreshRSS instance.
3. Zaclys instance as they too no longer provide RSS instance.

Updated the RSS direct instance details and URLs, so that they take users to the correct place instead of having to find, navigate, locate and what not in the pages of the domains they are hosted in. Makes it much simpler and directs to path of the instance itself.