### PR TITLE
cloud-providers: move offering page on decent.im

### DIFF
--- a/pages/cloud-providers.html
+++ b/pages/cloud-providers.html
@@ -39,7 +39,7 @@ description: You could be using FreshRSS in a few minutes.
             </p>
 
             <p>
-                <strong><a href="https://decent.im/newsreader/">Offering</a></strong>
+                <strong><a href="https://news.decent.im/i/?c=customer&a=checkout">Offering</a></strong>
                 <small> ⋅ <a href="https://news.decent.im/i/?a=tos">ToS</a></small>
                 <small> ⋅ <a href="https://github.com/decent-im/FreshRSS">Code</a></small>
                 <small> ⋅ <a href="https://news.decent.im/">FreshRSS</a></small>


### PR DESCRIPTION
The page explaining the offering has been moved into FreshRSS itself, to embed the payment form into it.

Thanks.