### PR TITLE
Replace spacebarlabs.com with cloudbreak.app

### DIFF
--- a/pages/cloud-providers.html
+++ b/pages/cloud-providers.html
@@ -153,18 +153,18 @@ description: You could be using FreshRSS in a few minutes.
 
 	  <div class="card flow-small">
             <div class="card__title">
-              Space Bar Labs
+              CloudBreak
             </div>
 
             <p class="text-secondary">
-              English, $1.25 / month or $12 / year (save 20%)
+              English, <a href="https://cloudbreak.app/freshrss/">competitive pricing</a>
             </p>
 
             <p>
-              <strong><a href="https://www.spacebarlabs.com">spacebarlabs.com</a></strong>
+              <strong><a href="https://cloudbreak.app">cloudbreak.app</a></strong>
               <small> ⋅ <a href="https://spacebarlabs.com/privacy-policy/">PP</a></small>
               <small> ⋅ <a href="https://spacebarlabs.com/terms-of-service/">ToS</a></small>
-              <small> ⋅ <a href="https://freshrss.spacebarlabs.com">FreshRSS</a></small>
+              <small> ⋅ <a href="https://cloudbreak.app/freshrss/">FreshRSS</a></small>
             </p>
          </div>
     </div>


### PR DESCRIPTION
Hello,

We originally added this link in https://github.com/FreshRSS/freshrss.org/pull/81.  We've since decided to use a new domain: [cloudbreak.app](https://cloudbreak.app).  This PR adjusts the domain and related wording accordingly.  Please let us know if you have any questions.

Take care,

Ben and Zach