### PR TITLE
fix: good-first-issue label missing emoji

### DIFF
--- a/index.html
+++ b/index.html
@@ -209,7 +209,7 @@ description: FreshRSS is lightweight, easy to work with, powerful, and customiza
                 <a href="contact.html">Contact us</a>
             </li>
             <li>
-                <a href="https://github.com/FreshRSS/FreshRSS/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22">Contribute</a>
+                <a href="https://github.com/FreshRSS/FreshRSS/issues?q=is%3Aopen%20is%3Aissue%20label%3A%22Good%20first%20issue%201%EF%B8%8F%E2%83%A3%22">Contribute</a>
             </li>
             <li>
                 <a href="https://github.com/FreshRSS/FreshRSS/blob/edge/CREDITS.md">Be credited</a>


### PR DESCRIPTION
The link resulted in an empty page because the label got renamed with an emoji: `Good first issue ` vs `Good first issue 1️⃣`