### PR TITLE
feat(cloud-providers): split into public and dedicated managed sections

### DIFF
--- a/pages/cloud-providers.html
+++ b/pages/cloud-providers.html
@@ -14,13 +14,13 @@ description: You could be using FreshRSS in a few minutes.
 
     <!--
         Maintainer notes:
-        - Cards are sorted alphabetically within each section, with
-          `card--full` (closed) cards moved to the end of their section.
+        - Cards are sorted alphabetically within each section in the source.
+          `card--full` (closed) cards are auto-reordered to the end of their
+          section by CSS, so source order can stay alphabetical.
         - To mark an instance as closed to new registrations, add the
-          `card--full` class to its `<div class="card ...">` and move it
-          below the open cards. Remove the class and re-sort when
-          registrations reopen. If an instance disappears entirely, remove
-          its card.
+          `card--full` class to its `<div class="card ...">`. Remove the
+          class when registrations reopen. If an instance disappears
+          entirely, remove its card.
         - To mark an instance as supporting FreshRSS financially (e.g. a
           revenue share or kickback agreement), add the `card--kickback`
           class. A "Supports FreshRSS" badge is shown next to the card
@@ -38,6 +38,21 @@ description: You could be using FreshRSS in a few minutes.
     </p>
 
     <div class="grid">
+
+        <div class="card card--full flow-small">
+            <div class="card__title">
+                Chère de Prince
+            </div>
+
+            <p class="text-secondary">
+                France ⋅ Free
+            </p>
+
+            <p>
+                <strong><a href="https://cheredeprince.net/">cheredeprince.net</a></strong>
+                <small> ⋅ <a href="https://rss.cheredeprince.net/">FreshRSS</a></small>
+            </p>
+        </div>
 
         <div class="card flow-small">
             <div class="card__title">
@@ -83,6 +98,21 @@ description: You could be using FreshRSS in a few minutes.
             <p>
                 <strong><a href="https://hostux.network/">hostux.network</a></strong>
                 <small> ⋅ <a href="https://rss.hostux.net/">FreshRSS</a></small>
+            </p>
+        </div>
+
+        <div class="card card--full flow-small">
+            <div class="card__title">
+                Prodottoinrete Group SRL
+            </div>
+
+            <p class="text-secondary">
+                Italy ⋅ Free
+            </p>
+
+            <p>
+                <strong><a href="https://prodottoinrete.com/">prodottoinrete.com</a></strong>
+                <small> ⋅ <a href="https://freshrss.prodottoinrete.com/">FreshRSS</a></small>
             </p>
         </div>
 
@@ -143,36 +173,6 @@ description: You could be using FreshRSS in a few minutes.
             <p>
                 <strong><a href="https://www.zaclys.com/">zaclys.com</a></strong>
                 <small> ⋅ <a href="https://www.zaclys.com/flux/">FreshRSS</a></small>
-            </p>
-        </div>
-
-        <div class="card card--full flow-small">
-            <div class="card__title">
-                Chère de Prince
-            </div>
-
-            <p class="text-secondary">
-                France ⋅ Free
-            </p>
-
-            <p>
-                <strong><a href="https://cheredeprince.net/">cheredeprince.net</a></strong>
-                <small> ⋅ <a href="https://rss.cheredeprince.net/">FreshRSS</a></small>
-            </p>
-        </div>
-
-        <div class="card card--full flow-small">
-            <div class="card__title">
-                Prodottoinrete Group SRL
-            </div>
-
-            <p class="text-secondary">
-                Italy ⋅ Free
-            </p>
-
-            <p>
-                <strong><a href="https://prodottoinrete.com/">prodottoinrete.com</a></strong>
-                <small> ⋅ <a href="https://freshrss.prodottoinrete.com/">FreshRSS</a></small>
             </p>
         </div>
 

--- a/pages/cloud-providers.html
+++ b/pages/cloud-providers.html
@@ -7,26 +7,37 @@ description: You could be using FreshRSS in a few minutes.
     <div class="site__intro text-featured wrapper-text">
         <p>
             <strong>You could be using FreshRSS in a few minutes.</strong><br>
-            The community proposes ready-to-go servers.
+            Pick a public instance to share with other users, or a dedicated
+            managed instance just for you.
         </p>
     </div>
 
+    <!--
+        Maintainer notes:
+        - Cards are sorted alphabetically within each section, with
+          `card--full` (closed) cards moved to the end of their section.
+        - To mark an instance as closed to new registrations, add the
+          `card--full` class to its `<div class="card ...">` and move it
+          below the open cards. Remove the class and re-sort when
+          registrations reopen. If an instance disappears entirely, remove
+          its card.
+        - To mark an instance as supporting FreshRSS financially (e.g. a
+          revenue share or kickback agreement), add the `card--kickback`
+          class. A "Supports FreshRSS" badge is shown next to the card
+          title. Remove the class if the arrangement ends.
+        - The two classes can be combined on the same card.
+        - Country, pricing and instance type live in the
+          `<p class="text-secondary">` line so users can scan quickly.
+    -->
+
+    <h2 id="public-instances" class="title">Public instances</h2>
+
+    <p class="text-featured wrapper-text">
+        Shared servers run by community members. Create an account and start
+        reading.
+    </p>
+
     <div class="grid">
-
-        <div class="card flow-small">
-            <div class="card__title">
-                Chère de Prince
-            </div>
-
-            <p class="text-secondary">
-                French, free
-            </p>
-
-            <p>
-                <strong><a href="https://cheredeprince.net/">cheredeprince.net</a></strong>
-                <small> ⋅ <a href="https://rss.cheredeprince.net/">FreshRSS</a></small>
-            </p>
-        </div>
 
         <div class="card flow-small">
             <div class="card__title">
@@ -34,8 +45,7 @@ description: You could be using FreshRSS in a few minutes.
             </div>
 
             <p class="text-secondary">
-	        With modern speech synthesizer PiperTTS on high settings.<br>
-	        30 days trial, 20&nbsp;£&nbsp;/&nbsp;year. Ask for a free account if you do public interest work.
+                £20&nbsp;/&nbsp;year (30-day trial; free for public-interest work) ⋅ With PiperTTS speech synthesis
             </p>
 
             <p>
@@ -52,7 +62,7 @@ description: You could be using FreshRSS in a few minutes.
             </div>
 
             <p class="text-secondary">
-                Quebec, pay what you want
+                Quebec, Canada ⋅ Pay what you want
             </p>
 
             <p>
@@ -67,7 +77,7 @@ description: You could be using FreshRSS in a few minutes.
             </div>
 
             <p class="text-secondary">
-                French, pay what you want
+                France ⋅ Free
             </p>
 
             <p>
@@ -78,26 +88,11 @@ description: You could be using FreshRSS in a few minutes.
 
         <div class="card flow-small">
             <div class="card__title">
-                Prodottoinrete Group SRL
-            </div>
-
-            <p class="text-secondary">
-                Italian, free
-            </p>
-
-            <p>
-                <strong><a href="https://prodottoinrete.com/">prodottoinrete.com</a></strong>
-                <small> ⋅ <a href="https://freshrss.prodottoinrete.com/">FreshRSS</a></small>
-            </p>
-        </div>
-
-        <div class="card flow-small">
-            <div class="card__title">
                 Siick's Services
             </div>
 
             <p class="text-secondary">
-                French, pay what you want
+                France ⋅ Pay what you want, on request
             </p>
 
             <p>
@@ -108,11 +103,41 @@ description: You could be using FreshRSS in a few minutes.
 
         <div class="card flow-small">
             <div class="card__title">
+                Websitemachine
+            </div>
+
+            <p class="text-secondary">
+                Netherlands ⋅ Free
+            </p>
+
+            <p>
+                <strong><a href="https://www.websitemachine.nl/">websitemachine.nl</a></strong>
+                <small> ⋅ <a href="https://reader.websitemachine.nl/">FreshRSS</a></small>
+            </p>
+        </div>
+
+        <div class="card flow-small">
+            <div class="card__title">
+                WoodPeckersNest (WPN)
+            </div>
+
+            <p class="text-secondary">
+                Italy ⋅ Free
+            </p>
+
+            <p>
+                <strong><a href="https://woodpeckersnest.space/">woodpeckersnest.space</a></strong>
+                <small> ⋅ <a href="https://rss.woodpeckersnest.space/">FreshRSS</a></small>
+            </p>
+        </div>
+
+        <div class="card flow-small">
+            <div class="card__title">
                 Zaclys
             </div>
 
             <p class="text-secondary">
-                French, 10&nbsp;€&nbsp;/&nbsp;year
+                France ⋅ 10&nbsp;€&nbsp;/&nbsp;year
             </p>
 
             <p>
@@ -121,52 +146,124 @@ description: You could be using FreshRSS in a few minutes.
             </p>
         </div>
 
-          <div class="card flow-small">
+        <div class="card card--full flow-small">
             <div class="card__title">
-              Websitemachine
+                Chère de Prince
             </div>
 
             <p class="text-secondary">
-              English / Dutch, Free.
+                France ⋅ Free
             </p>
 
             <p>
-              <strong><a href="https://www.websitemachine.nl/">Websitemachine</a></strong>
-              <small> ⋅ <a href="https://reader.websitemachine.nl/">FreshRSS</a></small>
-            </p>
-          </div>
-
-        <div class="card flow-small">
-            <div class="card__title">
-                WoodPeckersNest (WPN)
-            </div>
-
-            <p class="text-secondary">
-                English / Italian, Free.
-            </p>
-
-            <p>
-                <strong><a href="https://woodpeckersnest.space/">wpn</a></strong>
-                <small> ⋅ <a href="https://rss.woodpeckersnest.space/">FreshRSS</a></small>
+                <strong><a href="https://cheredeprince.net/">cheredeprince.net</a></strong>
+                <small> ⋅ <a href="https://rss.cheredeprince.net/">FreshRSS</a></small>
             </p>
         </div>
 
-	  <div class="card flow-small">
+        <div class="card card--full flow-small">
             <div class="card__title">
-              CloudBreak
+                Prodottoinrete Group SRL
             </div>
 
             <p class="text-secondary">
-              English, <a href="https://cloudbreak.app/freshrss/">competitive pricing</a>
+                Italy ⋅ Free
             </p>
 
             <p>
-              <strong><a href="https://cloudbreak.app">cloudbreak.app</a></strong>
-              <small> ⋅ <a href="https://spacebarlabs.com/privacy-policy/">PP</a></small>
-              <small> ⋅ <a href="https://spacebarlabs.com/terms-of-service/">ToS</a></small>
-              <small> ⋅ <a href="https://cloudbreak.app/freshrss/">FreshRSS</a></small>
+                <strong><a href="https://prodottoinrete.com/">prodottoinrete.com</a></strong>
+                <small> ⋅ <a href="https://freshrss.prodottoinrete.com/">FreshRSS</a></small>
             </p>
-         </div>
+        </div>
+
+    </div>
+
+    <h2 id="dedicated-managed" class="title">Dedicated managed hosting</h2>
+
+    <p class="text-featured wrapper-text">
+        Pay-as-you-go services that run a FreshRSS instance just for you. No
+        server admin required.
+    </p>
+
+    <div class="grid">
+
+        <div class="card flow-small">
+            <div class="card__title">
+                ClawCloud Run
+            </div>
+
+            <p class="text-secondary">
+                Tiered pricing
+            </p>
+
+            <p>
+                <strong><a href="https://run.claw.cloud/">run.claw.cloud</a></strong>
+                <small> ⋅ <a href="https://template.run.claw.cloud/?openapp=system-fastdeploy%3FtemplateName%3Dfreshrss">Deploy FreshRSS</a></small>
+            </p>
+        </div>
+
+        <div class="card flow-small">
+            <div class="card__title">
+                CloudBreak
+            </div>
+
+            <p class="text-secondary">
+                United States and Canada only ⋅ <a href="https://cloudbreak.app/freshrss/">$36&nbsp;/&nbsp;year</a>
+            </p>
+
+            <p>
+                <strong><a href="https://cloudbreak.app">cloudbreak.app</a></strong>
+                <small> ⋅ <a href="https://spacebarlabs.com/privacy-policy/">PP</a></small>
+                <small> ⋅ <a href="https://spacebarlabs.com/terms-of-service/">ToS</a></small>
+                <small> ⋅ <a href="https://cloudbreak.app/freshrss/">FreshRSS</a></small>
+            </p>
+        </div>
+
+        <div class="card flow-small">
+            <div class="card__title">
+                Elestio
+            </div>
+
+            <p class="text-secondary">
+                20 countries ⋅ from $14&nbsp;/&nbsp;month
+            </p>
+
+            <p>
+                <strong><a href="https://elest.io/">elest.io</a></strong>
+                <small> ⋅ <a href="https://elest.io/open-source/freshrss">FreshRSS</a></small>
+            </p>
+        </div>
+
+        <div class="card flow-small">
+            <div class="card__title">
+                PikaPods
+            </div>
+
+            <p class="text-secondary">
+                European Union and United States ⋅ from $1.20&nbsp;/&nbsp;month
+            </p>
+
+            <p>
+                <strong><a href="https://www.pikapods.com/">pikapods.com</a></strong>
+                <small> ⋅ <a href="https://www.pikapods.com/pods?run=freshrss">Deploy FreshRSS</a></small>
+            </p>
+        </div>
+
+        <div class="card flow-small">
+            <div class="card__title">
+                Zeabur
+            </div>
+
+            <p class="text-secondary">
+                Tiered pricing
+            </p>
+
+            <p>
+                <strong><a href="https://zeabur.com/">zeabur.com</a></strong>
+                <small> ⋅ <a href="https://zeabur.com/templates/MD4TRW">Deploy FreshRSS</a></small>
+            </p>
+        </div>
+
     </div>
 
     <p class="text-featured">

--- a/static/style.css
+++ b/static/style.css
@@ -263,6 +263,7 @@ a {
 }
 
 .card--full {
+    order: 1;
     opacity: 0.55;
 }
 

--- a/static/style.css
+++ b/static/style.css
@@ -262,6 +262,46 @@ a {
     background-color: var(--color-primary3);
 }
 
+.card--full {
+    opacity: 0.55;
+}
+
+.card--full .card__title::after {
+    display: inline-block;
+    margin-left: 0.5rem;
+    padding: 0.1rem 0.4rem;
+
+    content: "Registrations closed";
+
+    color: var(--color-primary1);
+    font-family: "Open Sans", sans-serif;
+    font-size: 0.7rem;
+    font-style: normal;
+    font-weight: normal;
+    vertical-align: middle;
+
+    background-color: var(--color-primary11);
+    border-radius: 0.25rem;
+}
+
+.card--kickback .card__title::before {
+    display: inline-block;
+    margin-right: 0.5rem;
+    padding: 0.1rem 0.4rem;
+
+    content: "Supports FreshRSS";
+
+    color: var(--color-primary1);
+    font-family: "Open Sans", sans-serif;
+    font-size: 0.7rem;
+    font-style: normal;
+    font-weight: normal;
+    vertical-align: middle;
+
+    background-color: var(--color-primary9);
+    border-radius: 0.25rem;
+}
+
 .card__title {
     font-size: 1.2rem;
     font-family: "PT Serif", serif;


### PR DESCRIPTION
Addresses FreshRSS/FreshRSS#7628 for the cloud-providers.html side.

## What changed

- Two sections: **Public instances** and **Dedicated managed hosting**. Instance type is communicated by section; each card shows country (where verifiable) and pricing on one line.
- New \`card--full\` and \`card--kickback\` modifier classes for capacity and revenue-share status. \`card--full\` dims the card, shows a "Registrations closed" badge, and auto-reorders the card to the end of its section via CSS so the source HTML can stay alphabetical. Applied to Chère de Prince and Prodottoinrete.
- Added four managed providers from the README's Automated install table: ClawCloud, Elestio, PikaPods, Zeabur. They remain in the README; that cleanup is a separate follow-up.
- Maintainer-notes HTML comment documenting both classes and the sort order.

## Issue checklist

| Ask | Done on this side |
|---|---|
| Self-host vs cloud | Cloud side reorganised here; README cleanup is the follow-up |
| Dedicated vs public instance | Yes (two sections) |
| Country | Yes, where verifiable |
| Capacity (mark or remove?) | Marked. Open to removing if you prefer |
| Pricing | Yes |
| Kickback to FreshRSS | Class is ready, application needs your input |

## Open questions

1. **Kickback flags**: class is in place but not applied. Two providers have public revenue-share commitments:
   - CloudBreak: "10% Open Source Pledge"
   - PikaPods: "20% revenue share with project authors where possible"

   Which providers, if any, should get \`card--kickback\`?

2. **Closed instances**: marked rather than removed. Issue says "(or remove?)". Let me know.

3. **Cards without a country**: Decent.im, ClawCloud and Zeabur don't list country / data centre information I could verify. Do you have details for any of them?

4. **Country inferences I made from secondary signals**:
   - Hostux -> France (existing card said "French")
   - WoodPeckersNest -> Italy (existing card said "English / Italian")

   Neither is stated explicitly on the provider's site. Revert to language-only if preferred.

5. **Hostux pricing**: changed \`pay what you want\` to \`Free\` because hostux.network says "100% free". Soften to \`Free, donations welcome\`?

6. **CloudBreak**: replaced \`competitive pricing\` with \`\$36 / year\` and added "United States and Canada only" from their current signup page. More likely to go stale. OK?

## Screenshots
<img width="979" height="773" alt="Screenshot 2026-05-02 at 20 20 25" src="https://github.com/user-attachments/assets/b6dfcbe0-131c-4c69-a87c-d93aa82f3055" />

<img width="979" height="595" alt="Screenshot 2026-05-02 at 20 20 49" src="https://github.com/user-attachments/assets/988d5aa6-b41e-4d7a-92c8-aad6b3309f2c" />

Built and rendered locally with boop.
