### PR TITLE
feat(cloud-providers): link to CHATONS directory

### DIFF
--- a/pages/cloud-providers.html
+++ b/pages/cloud-providers.html
@@ -178,6 +178,11 @@ description: You could be using FreshRSS in a few minutes.
 
     </div>
 
+    <p class="text-featured wrapper-text">
+        See also the <a href="https://www.chatons.org/search/by-service?field_software_target_id=269">CHATONS directory</a>
+        for more community-run FreshRSS instances.
+    </p>
+
     <h2 id="dedicated-managed" class="title">Dedicated managed hosting</h2>
 
     <p class="text-featured wrapper-text">


### PR DESCRIPTION
Follow-up to #92 ([comment](https://github.com/FreshRSS/freshrss.org/pull/92#issuecomment-4364611803)).

Adds a short reference to the [CHATONS directory of FreshRSS services](https://www.chatons.org/search/by-service?field_software_target_id=269) under the **Public instances** heading, immediately after the instance grid and before the **Dedicated managed hosting** heading.

## Open question

Of the 5 FreshRSS entries currently in the CHATONS directory, 4 are already listed on this page (Chère de Prince, FACiL, Siick's Services, Zaclys). The only one missing is **Simon Vieille / Deblan** (France, free, run by an individual; FreshRSS at `rss.deblan.org`).

Linking CHATONS without also listing Deblan is a bit inconsistent with how the other 4 are handled, so two options:

- **A (this PR as-is):** keep the prominent CHATONS callout, leave Deblan unlisted.
  > See also the CHATONS directory for more community-run FreshRSS instances.
- **B:** add a Deblan card alphabetically and shrink the CHATONS reference to a smaller line. Keeps per-instance discoverability consistent.
  > More community-run instances are listed in the CHATONS directory.

Happy to switch to B before merging if preferred.

## Screenshot
<img width="773" height="308" alt="Screenshot 2026-05-03 at 16 19 17" src="https://github.com/user-attachments/assets/368f76f0-8586-4460-bcc2-f58dab03f19e" />

## Verification

- Built locally and confirmed the link renders correctly under Public instances.
- CHATONS URL returns 200 and the FreshRSS results page.